### PR TITLE
Added Get-MrManifestData

### DIFF
--- a/MrModuleBuildTools/public/Get-MrManifestData.ps1
+++ b/MrModuleBuildTools/public/Get-MrManifestData.ps1
@@ -1,0 +1,38 @@
+﻿function Get-MrManifestData {
+    [CmdletBinding(DefaultParameterSetName='File')]
+    param(
+        [Parameter(ValueFromPipeline,
+                   ValueFromPipelineByPropertyName,
+                   ValueFromRemainingArguments,
+                   ParameterSetName = 'File',
+                   Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('FilePath')]
+        [string[]]$Path = ('.\*.psd1'),
+
+        [Parameter(ValueFromPipelineByPropertyName,
+                   ValueFromRemainingArguments,
+                   ParameterSetName = 'Code',
+                   Position = 0)]
+        [ValidateNotNull()]
+        [Alias('ScriptBlock')]
+        [string[]]$Code
+    )
+
+    PROCESS {
+        if ($PSBoundParameters.Path) {
+            Write-Verbose 'Path'
+            $Results = Get-MrAST -Path $Path
+        }
+        elseif ($PSBoundParameters.Code) {
+            Write-Verbose 'Code'
+            $Results = Get-MrAST -Code $Code
+        }
+        else {
+            Write-Verbose -Message 'Valid input not received.'
+        }
+        
+        $Results.EndBlock.Statements.pipelineElements.Expression.SafeGetValue()
+    }
+
+}


### PR DESCRIPTION
Get data from module manifest without importing module (i.e. get-module MrModuleBuildTools | select *)